### PR TITLE
few typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@ https://github.com/alex-shpak/hugo-book
 <li>tasklets</li>
 <li>microthreads</li>
 </ul>
-<p>There are very few and minor differences between fibers and the above list. For the purposes of this document, we should consider them equivlant as the distinctions don&rsquo;t quite matter.</p>
+<p>There are very few and minor differences between fibers and the above list. For the purposes of this document, we should consider them equivalent as the distinctions don&rsquo;t quite matter.</p>
 <h2 id="scheduling">
   Scheduling
   <a class="anchor" href="#scheduling">#</a>
@@ -1402,7 +1402,7 @@ However, if you do feel like implementing one yourself. Keep in mind that the pr
   <a href="https://kernel.dk/io_uring.pdf"><code>io_uring</code></a>. FreeBSD and macOS have
   <a href="https://en.wikipedia.org/wiki/Kqueue"><code>kqueue</code></a>. Windows has <code>poll</code> (but only for files, not sockets) and
   <a href="https://en.wikipedia.org/wiki/Input/output_completion_port"><code>IOCP</code></a>.</p>
-<p>As you can see by now, implementing this for multiple platforms requires multiple implementations of what is effectively an event loop. You can save yourself a lot of time and effort here if you pick an off the shelve event loop solution like
+<p>As you can see by now, implementing this for multiple platforms requires multiple implementations of what is effectively an event loop. You can save yourself a lot of time and effort here if you pick an off-the-shelf event loop solution like
   <a href="https://libuv.org/">libuv</a>.</p>
 </article>
 


### PR DESCRIPTION
also changed `off the shelf` to `off-the-shelf` (more common and a little easier to read)